### PR TITLE
Turn off `app_account_creation`

### DIFF
--- a/config/custom.exs
+++ b/config/custom.exs
@@ -4,6 +4,8 @@ config :pleroma, :instance,
   registrations_open: false,
   managed_config: false
 
+config :pleroma, :app_account_creation, enabled: false
+
 config :pleroma, :frontend_configurations,
   pleroma_fe: false,
   masto_fe: %{


### PR DESCRIPTION
https://github.com/kPherox/pleroma/commits/23b8ba82cad0ea419659fdc59d401fc8031fd327 で`app_account_creation`が有効にされてしまったのと、`registrations_open`の値を見てくれてはいない気がするので無効化する