### PR TITLE
Change to enable fetch initial posts

### DIFF
--- a/config/custom.exs
+++ b/config/custom.exs
@@ -21,3 +21,7 @@ config :pleroma, Pleroma.Uploaders.S3,
   bucket: "pleroma-kpherox",
   public_endpoint: "https://media.pl.kpherox.dev",
   truncated_namespace: ""
+
+config :pleroma, :fetch_initial_posts,
+  enabled: true,
+  pages: 3


### PR DESCRIPTION
多分フォローした時じゃなくてrepeatとかfavoriteとかされたりrepeatで流れてきたりしたときに、そのアカウントの投稿を取得しに行くやつかなって思ってる