### PR TITLE
Revert "Change to enable fetch initial posts"

### DIFF
--- a/config/custom.exs
+++ b/config/custom.exs
@@ -28,7 +28,3 @@ config :pleroma, Pleroma.Web.Federator.RetryQueue,
 
 config :pleroma_job_queue, :queues,
   background: 10
-
-config :pleroma, :fetch_initial_posts,
-  enabled: true,
-  pages: 3


### PR DESCRIPTION
Reverts #14

これ有効にしたら`beam.smp`ってプロセスがCPU利用率100%超えたりしてたのでRevertする