### PR TITLE
Fix handling pinned param

### DIFF
--- a/lib/pleroma/web/activity_pub/activity_pub.ex
+++ b/lib/pleroma/web/activity_pub/activity_pub.ex
@@ -839,7 +839,7 @@ defmodule Pleroma.Web.ActivityPub.ActivityPub do
     )
   end
 
-  defp restrict_pinned(query, %{"pinned" => "true", "pinned_activity_ids" => ids}) do
+  defp restrict_pinned(query, %{"pinned" => pinned, "pinned_activity_ids" => ids}) when pinned not in ["false", "f", "0", ""] do
     from(activity in query, where: activity.id in ^ids)
   end
 


### PR DESCRIPTION
クライアント側でpinned=1とか使って取得しているとpinnedの値が無視されるからMastodonの応答に合わせる