### PR TITLE
投稿にLinkヘッダつけるやつ

### DIFF
--- a/lib/pleroma/web/ostatus/ostatus_controller.ex
+++ b/lib/pleroma/web/ostatus/ostatus_controller.ex
@@ -86,6 +86,7 @@ defmodule Pleroma.Web.OStatus.OStatusController do
 
         activity.data["type"] == "Create" ->
           %Object{} = object = Object.normalize(activity)
+          put_resp_header(conn, "link", "<#{object.id}>; rel=\"alternate\"; type=\"application/activity+json\"")
 
           RedirectController.redirector_with_meta(
             conn,


### PR DESCRIPTION
なんか `/objects/:uuid` と `/notice/:id` で表示するページをリダイレクトするようになってからMastodonの検索で投稿取得できなくなってるけどそれを解消できるかもしれないってことでlinkヘッダをつけるやつ
`pl.kpherox.dev` に取り込んで修正されるようなら本家にもMR開く予定だけど治るかわからん