### PR TITLE
fix argument error in streamer

### DIFF
--- a/lib/pleroma/web/streamer/streamer.ex
+++ b/lib/pleroma/web/streamer/streamer.ex
@@ -136,7 +136,7 @@ defmodule Pleroma.Web.Streamer do
          false <- Pleroma.Web.ActivityPub.MRF.subdomain_match?(domain_blocks, item_host),
          false <- Pleroma.Web.ActivityPub.MRF.subdomain_match?(domain_blocks, parent_host),
          true <- thread_containment(item, user),
-         false <- CommonAPI.thread_muted?(user, item) do
+         false <- !is_nil(parent.data["context"]) && CommonAPI.thread_muted?(user, parent) do
       false
     else
       _ -> true


### PR DESCRIPTION
Announce Activity's context is null and `Repo.exists` can't use `nil` as it is unsafe.

本当に `parent` でいいのか？