### PR TITLE
docker: bump to elixir v1.13.4 and alpine 3.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10-alpine as build
+FROM hexpm/elixir:1.13.4-erlang-23.2.7.5-alpine-3.16.0 as build
 
 COPY . .
 
@@ -12,7 +12,7 @@ RUN apk add git gcc g++ musl-dev make cmake file-dev &&\
 	mkdir release &&\
 	mix release --path release
 
-FROM alpine
+FROM alpine:3.16.0
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
change elixir image to hexpm/elixir