### PR TITLE
docker: add ERL_FLAGS for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM elixir:1.11.4-alpine as build
 
 COPY . .
 
+ARG ERL_FLAGS
+ENV ERL_FLAGS="${ERL_FLAGS}"
 ENV MIX_ENV=prod
 
 RUN apk add git gcc g++ musl-dev make cmake file-dev &&\


### PR DESCRIPTION
Erlang/OTP 25 using JIT, but multi-arch build with QEMU user mode cannot dual mapping writable and executable. So required to add `+JPperf true`(24.0+) or `+JMsingle true`(master).